### PR TITLE
Silent SSO-fiksing

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ const App = () => {
   <details>
     <summary>Parameters</summary>
     <ul>
-      <li>options (object) - <a href="https://azuread.github.io/microsoft-authentication-library-for-js/ref/msal-browser/modules/_src_request_redirectrequest_.html#redirectrequest">loginRequest</a> <i>(required)</i></li> 
+      <li>options (object) - <a href="https://azuread.github.io/microsoft-authentication-library-for-js/ref/modules/_azure_msal_browser.html#redirectrequest">loginRequest</a> <i>(required)</i></li>
       <li>method (string): loginRedirect or loginPopup</ul>
   </details>
 - `logout` (function) - trigger logout (clears session storage and redirects to azure)
@@ -98,34 +98,33 @@ const App = () => {
   <details>
     <summary>Parameters</summary>
     <ul>
-      <li>options (object) - <a href="https://azuread.github.io/microsoft-authentication-library-for-js/ref/msal-browser/modules/_src_request_redirectrequest_.html#redirectrequest">loginRequest</a> <i>(required)</i></li> 
-      <li>method (string): loginRedirect or loginPopup</ul>
+      <li>options (object) - <a href="https://azuread.github.io/microsoft-authentication-library-for-js/ref/modules/_azure_msal_browser.html#redirectrequest">loginRequest</a> <i>(required)</i></li>
   </details>
 - `apiGet` (function) - gets data from provided URL using the users id_token
   <details>
     <summary>Parameters</summary>
     <ul>
-      <li>url (string) <i>(required)</i></li> 
+      <li>url (string) <i>(required)</i></li>
   </details>
 - `apiPost` (function) - posts the provided data to the URL using the users id_token
   <details>
     <summary>Parameters</summary>
     <ul>
-      <li>url (string) <i>(required)</i></li> 
+      <li>url (string) <i>(required)</i></li>
       <li>data  <i>(required)</i></ul>
   </details>
 - `apiPut` (function) - updates/put the provided data to the URL using the users id_token
   <details>
     <summary>Parameters</summary>
     <ul>
-      <li>url (string) <i>(required)</i></li> 
+      <li>url (string) <i>(required)</i></li>
       <li>data  <i>(required)</i></ul>
   </details>
 - `apiDelete` (function) - deletes data from provided URL using the users id_token
   <details>
     <summary>Parameters</summary>
     <ul>
-      <li>url (string) <i>(required)</i></li> 
+      <li>url (string) <i>(required)</i></li>
   </details>
 
 #### User object


### PR DESCRIPTION
- Endret fra user til account, for å være konsekvent med begrepene
- Byttet ut stedene `user` ble gitt med i `updateToken()`-metoden til `account` fra publicClient (i stedet for Graph-objektet)
   Dette står beskrevet i dokumentasjonen til Microsoft [her](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/8578174835412d152489b0098f2ea6b0a5ce9ad3/lib/msal-browser/docs/token-lifetimes.md#token-renewal):
   
   > 5 - If the refresh token is expired, MSAL will attempt to retrieve an access tokens silently using a hidden iframe. **This will use the sid or username in the account's claims object to retrieve a hint about the user's session.** **If this hidden iframe call fails, MSAL will pass on an error from the server as an InteractionRequiredAuthError,** asking to retrieve an authorization code to retrieve a new set of tokens. You can do this by performing a login or acquireToken API call with the PublicClientApplication object. If the session is still active, the server will send a code without any user prompts. Otherwise, the user will be required to enter their credentials.
   
   Tror dette gir mer mening nå enn før, hvor graph-brukeren ble gitt med enkelte steder, som ikke inneholder sid eller username på samme måte som [publicClient account-objektet gjør](https://github.com/AzureAD/microsoft-authentication-library-for-js/blob/310ab2c2c/lib/msal-common/src/cache/entities/AccountEntity.ts#L46-L60).

**_IKKE TESTET ENDA, SÅ DET BØR SIKKERT GJØRES FØR DET PRØVES I PRODUKSJON 🤓_**