### PR TITLE
Return full response

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,26 +105,34 @@ const App = () => {
     <summary>Parameters</summary>
     <ul>
       <li>url (string) <i>(required)</i></li>
+      <li>returnFullResponse (bool) <i>(optional) <b>default = false</b></li>
+    </ul>
   </details>
 - `apiPost` (function) - posts the provided data to the URL using the users id_token
   <details>
     <summary>Parameters</summary>
     <ul>
       <li>url (string) <i>(required)</i></li>
-      <li>data  <i>(required)</i></ul>
+      <li>data  <i>(required)</i>
+      <li>returnFullResponse (bool) <i>(optional) <b>default = false</b></li>
+    </ul>
   </details>
 - `apiPut` (function) - updates/put the provided data to the URL using the users id_token
   <details>
     <summary>Parameters</summary>
     <ul>
       <li>url (string) <i>(required)</i></li>
-      <li>data  <i>(required)</i></ul>
+      <li>data  <i>(required)</i>
+      <li>returnFullResponse (bool) <i>(optional) <b>default = false</b></li>
+    </ul>
   </details>
 - `apiDelete` (function) - deletes data from provided URL using the users id_token
   <details>
     <summary>Parameters</summary>
     <ul>
       <li>url (string) <i>(required)</i></li>
+      <li>returnFullResponse (bool) <i>(optional) <b>default = false</b></li>
+    </ul>
   </details>
 
 #### User object

--- a/src/config.js
+++ b/src/config.js
@@ -21,6 +21,6 @@ export default {
     storeAuthStateInCookie: process.env.AUTH_STATE_IN_COOKIE === 'true' || false
   },
   userInfoUrl: process.env.AUTH_USER_INFO_URL || 'https://graph.microsoft.com/v1.0/me?$select=userPrincipalName,onPremisesSamaccountName,givenName,surname,displayName',
-  isMock: process.env.AUTH_IS_MOCK || process.env.REACT_APP_IS_MOCK || false,
+  isMock: (process.env.AUTH_IS_MOCK && process.env.AUTH_IS_MOCK === 'true') || (process.env.REACT_APP_IS_MOCK && process.env.REACT_APP_IS_MOCK === 'true') || false,
   mockUser: process.env.AUTH_MOCK_USER ? JSON.parse(process.env.AUTH_MOCK_USER) : defaultMockUser
 }

--- a/src/lib/auth-provider.js
+++ b/src/lib/auth-provider.js
@@ -222,12 +222,12 @@ export const MsalProvider = ({
   const is401 = error => /401/.test(error.message)
   const isValid = (token, expires) => token && expires > new Date().getTime()
 
-  const retry = async func => {
+  const retry = async (func, returnFullResponse) => {
     if (isValid(idToken, expires)) {
       axios.defaults.headers.common.Authorization = `Bearer ${idToken}`
       try {
-        const { data } = await func()
-        return data
+        const res = await func()
+        return !returnFullResponse ? res.data : res
       } catch (error) {
         if (is401(error)) {
           const accounts = publicClient.getAllAccounts()
@@ -235,8 +235,8 @@ export const MsalProvider = ({
 
           axios.defaults.headers.common.Authorization = `Bearer ${idToken}`
           try {
-            const { data } = await func()
-            return data
+            const res = await func()
+            return !returnFullResponse ? res.data : res
           } catch (error) {
             console.error(error)
             return false
@@ -255,10 +255,10 @@ export const MsalProvider = ({
     }
   }
 
-  const apiGet = url => retry(() => axios.get(url))
-  const apiPost = (url, payload) => retry(() => axios.post(url, payload))
-  const apiPut = (url, payload) => retry(() => axios.put(url, payload))
-  const apiDelete = url => retry(() => axios.delete(url))
+  const apiGet = (url, returnFullResponse = false) => retry(() => axios.get(url), returnFullResponse)
+  const apiPost = (url, payload, returnFullResponse = false) => retry(() => axios.post(url, payload), returnFullResponse)
+  const apiPut = (url, payload, returnFullResponse = false) => retry(() => axios.put(url, payload), returnFullResponse)
+  const apiDelete = (url, returnFullResponse = false) => retry(() => axios.delete(url), returnFullResponse)
 
   return (
     <MsalContext.Provider


### PR DESCRIPTION
- Fikset en bug hvor `isMock` ble returnert som en string og ikke en boolean
- Lagt til en valgfri option i `apiGet`, `apiPost`, `apiPut` og `apiDelete` for å få returnert hele axios resultatet. Optionen er satt default til `false` så systemer som bruker disse skal ikke trenge å gjøre noen endringer.